### PR TITLE
Fix linspace for numpy 1.18

### DIFF
--- a/lvis/eval.py
+++ b/lvis/eval.py
@@ -520,10 +520,10 @@ class Params:
         # np.arange causes trouble.  the data point on arange is slightly
         # larger than the true value
         self.iou_thrs = np.linspace(
-            0.5, 0.95, np.round((0.95 - 0.5) / 0.05) + 1, endpoint=True
+            0.5, 0.95, int(np.round((0.95 - 0.5) / 0.05)) + 1, endpoint=True
         )
         self.rec_thrs = np.linspace(
-            0.0, 1.00, np.round((1.00 - 0.0) / 0.01) + 1, endpoint=True
+            0.0, 1.00, int(np.round((1.00 - 0.0) / 0.01)) + 1, endpoint=True
         )
         self.max_dets = 300
         self.area_rng = [


### PR DESCRIPTION
Since numpy 1.18 the `num` parameter in [np.linspace](https://numpy.org/doc/1.18/reference/generated/numpy.linspace.html) has to be an integer. This led to errors with the cocoapi as reported [here](https://github.com/numpy/numpy/issues/15192) and [here](https://github.com/cocodataset/cocoapi/pull/354). 

Running `eval.py` in the lvis-api throws the same error when using numpy 1.18. This pr follows https://github.com/cocodataset/cocoapi/pull/354 to fix the issue in the same way it was fixed for the cocoapi.