### PR TITLE
Reduce memory usage and time consumption with large cpu cores.

### DIFF
--- a/lvis/boundary_utils.py
+++ b/lvis/boundary_utils.py
@@ -7,6 +7,46 @@ import pycocotools.mask as mask_utils
 
 logger = logging.getLogger(__name__)
 
+MAX_CPU_NUM = 80
+
+
+def ann_to_rle(ann, imgs):
+    """Convert annotation which can be polygons, uncompressed RLE to RLE.
+    Args:
+        ann (dict) : annotation object
+
+    Returns:
+        ann (rle)
+    """
+    img_data = imgs[ann["image_id"]]
+    h, w = img_data["height"], img_data["width"]
+    segm = ann["segmentation"]
+    if isinstance(segm, list):
+        # polygon -- a single object might consist of multiple parts
+        # we merge all parts into one mask rle code
+        rles = mask_utils.frPyObjects(segm, h, w)
+        rle = mask_utils.merge(rles)
+    elif isinstance(segm["counts"], list):
+        # uncompressed RLE
+        rle = mask_utils.frPyObjects(segm, h, w)
+    else:
+        # rle
+        rle = ann["segmentation"]
+    return rle
+
+
+def ann_to_mask(ann, imgs):
+    """Convert annotation which can be polygons, uncompressed RLE, or RLE
+    to binary mask.
+    Args:
+        ann (dict) : annotation object
+
+    Returns:
+        binary mask (numpy 2D array)
+    """
+    rle = ann_to_rle(ann, imgs)
+    return mask_utils.decode(rle)
+
 
 # General util function to get the boundary of a binary mask.
 def mask_to_boundary(mask, dilation_ratio=0.02):
@@ -31,11 +71,11 @@ def mask_to_boundary(mask, dilation_ratio=0.02):
 
 
 # COCO/LVIS related util functions, to get the boundary for every annotations.
-def augment_annotations_with_boundary_single_core(proc_id, annotations, ann_to_mask, dilation_ratio=0.02):
+def augment_annotations_with_boundary_single_core(proc_id, annotations, imgs, dilation_ratio=0.02):
     new_annotations = []
 
     for ann in annotations:
-        mask = ann_to_mask(ann)
+        mask = ann_to_mask(ann, imgs)
         # Find mask boundary.
         boundary = mask_to_boundary(mask, dilation_ratio)
         # Add boundary to annotation in RLE format.
@@ -46,8 +86,8 @@ def augment_annotations_with_boundary_single_core(proc_id, annotations, ann_to_m
     return new_annotations
 
 
-def augment_annotations_with_boundary_multi_core(annotations, ann_to_mask, dilation_ratio=0.02):
-    cpu_num = multiprocessing.cpu_count()
+def augment_annotations_with_boundary_multi_core(annotations, imgs, dilation_ratio=0.02):
+    cpu_num = min(multiprocessing.cpu_count(), MAX_CPU_NUM)
     annotations_split = np.array_split(annotations, cpu_num)
     logger.info("Number of cores: {}, annotations per core: {}".format(cpu_num, len(annotations_split[0])))
     workers = multiprocessing.Pool(processes=cpu_num)
@@ -55,7 +95,7 @@ def augment_annotations_with_boundary_multi_core(annotations, ann_to_mask, dilat
 
     for proc_id, annotation_set in enumerate(annotations_split):
         p = workers.apply_async(augment_annotations_with_boundary_single_core,
-                                (proc_id, annotation_set, ann_to_mask, dilation_ratio))
+                                (proc_id, annotation_set, imgs, dilation_ratio))
         processes.append(p)
     
     new_annotations = []

--- a/lvis/boundary_utils.py
+++ b/lvis/boundary_utils.py
@@ -7,13 +7,12 @@ import pycocotools.mask as mask_utils
 
 logger = logging.getLogger(__name__)
 
-MAX_CPU_NUM = 80
-
 
 def ann_to_rle(ann, imgs):
     """Convert annotation which can be polygons, uncompressed RLE to RLE.
     Args:
         ann (dict) : annotation object
+        imgs (dict) : image dicts
 
     Returns:
         ann (rle)
@@ -40,6 +39,7 @@ def ann_to_mask(ann, imgs):
     to binary mask.
     Args:
         ann (dict) : annotation object
+        imgs (dict) : image dicts
 
     Returns:
         binary mask (numpy 2D array)
@@ -86,8 +86,8 @@ def augment_annotations_with_boundary_single_core(proc_id, annotations, imgs, di
     return new_annotations
 
 
-def augment_annotations_with_boundary_multi_core(annotations, imgs, dilation_ratio=0.02):
-    cpu_num = min(multiprocessing.cpu_count(), MAX_CPU_NUM)
+def augment_annotations_with_boundary_multi_core(annotations, imgs, dilation_ratio=0.02, max_cpu_num=80):
+    cpu_num = min(multiprocessing.cpu_count(), max_cpu_num)
     annotations_split = np.array_split(annotations, cpu_num)
     logger.info("Number of cores: {}, annotations per core: {}".format(cpu_num, len(annotations_split[0])))
     workers = multiprocessing.Pool(processes=cpu_num)

--- a/lvis/lvis.py
+++ b/lvis/lvis.py
@@ -61,7 +61,7 @@ class LVIS:
             self.logger.info('Adding `boundary` to annotation.')
             tic = time.time()
             self.dataset["annotations"] = augment_annotations_with_boundary_multi_core(self.dataset["annotations"],
-                                                                                       self.ann_to_mask,
+                                                                                       self.imgs,
                                                                                        dilation_ratio=self.dilation_ratio)
 
             self.logger.info('`boundary` added! (t={:0.2f}s)'.format(time.time()- tic))

--- a/lvis/results.py
+++ b/lvis/results.py
@@ -15,6 +15,7 @@ class LVISResults(LVIS):
         max_dets_per_im=300,
         precompute_boundary=False,
         dilation_ratio=0.02,
+        max_cpu_num=80,
     ):
         """Constructor for LVIS results.
         Args:
@@ -31,6 +32,7 @@ class LVISResults(LVIS):
                 (i.e., -1).
             precompute_boundary (bool): whether to precompute mask boundary before evaluation
             dilation_ratio (float): ratio to calculate dilation = dilation_ratio * image_diagonal
+            max_cpu_num (int): max number of cpu cores to compute mask boundary before evaluation
         """
         if isinstance(lvis_gt, LVIS):
             self.dataset = deepcopy(lvis_gt.dataset)
@@ -42,6 +44,7 @@ class LVISResults(LVIS):
 
         self.precompute_boundary = precompute_boundary
         self.dilation_ratio = dilation_ratio
+        self.max_cpu_num = max_cpu_num
 
         self.logger = logging.getLogger(__name__)
         self.logger.info("Loading and preparing results.")


### PR DESCRIPTION
In my machine with 88 cpu core and 360G memory, ```lvis_challenge_2021``` branch takes hours to evaluate boundary ap with 10k results per category, and finally it runs out of memory.

I find the problme is from ```augment_annotations_with_boundary_multi_core``` function.
The ```multiprocessing``` module will create 88 workers, each of which copies parent process memory.
Thus, it causes high memory usage and time consumption in a machine with large number of cpu cores.

I modified the codes and only pass necessary arguments to ```augment_annotations_with_boundary_single_core``` function, instead of the ```LVIS``` class.
I also limited the max number of works to 80 in ```multiprocessing``` module.

The modifed codes only use about 100G memory with 80 wokers in ```augment_annotations_with_boundary_single_core``` function.
And the time consumption of generating boundary for 20M results is about 500s.

