### PR TITLE
(fix) return non empty lists for category agnostic evaluation

### DIFF
--- a/lvis/eval.py
+++ b/lvis/eval.py
@@ -155,12 +155,12 @@ class LVISEval:
             gt = [
                 _ann
                 for _cat_id in self.params.cat_ids
-                for _ann in self._gts[img_id, cat_id]
+                for _ann in self._gts[img_id, _cat_id]
             ]
             dt = [
                 _ann
                 for _cat_id in self.params.cat_ids
-                for _ann in self._dts[img_id, cat_id]
+                for _ann in self._dts[img_id, _cat_id]
             ]
         return gt, dt
 


### PR DESCRIPTION
Hi

`cat_id` is set to -1 for category agnostic evaluation [here](https://github.com/lvis-dataset/lvis-api/blob/35f09cd7c5f313a9bf27b329ca80effe2b0c8a93/lvis/eval.py#L128).

Due to the present bug `self._gts[img_id, cat_id]` and `self._dts[img_id, cat_id]` are accessed with `cat_id` = -1, which doesn't exist. Therefore  `def _get_gt_dt()` returns empty lists if `self.use_cats = False` is specified.

This PR fixes this behavior, returning lists of all groundtruths and detections over all categories. This issue is also mentioned in #18 .