### PR TITLE
Fix np.float deprecation issue.

### DIFF
--- a/lvis/eval.py
+++ b/lvis/eval.py
@@ -358,7 +358,7 @@ class LVISEval:
                 tps = np.logical_and(dt_m, np.logical_not(dt_ig))
                 fps = np.logical_and(np.logical_not(dt_m), np.logical_not(dt_ig))
 
-                tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+                tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
                 fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
 
                 dt_pointers[cat_idx][area_idx] = {

--- a/lvis/eval.py
+++ b/lvis/eval.py
@@ -358,8 +358,8 @@ class LVISEval:
                 tps = np.logical_and(dt_m, np.logical_not(dt_ig))
                 fps = np.logical_and(np.logical_not(dt_m), np.logical_not(dt_ig))
 
-                tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
-                fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
+                tp_sum = np.cumsum(tps, axis=1).astype(dtype=float)
+                fp_sum = np.cumsum(fps, axis=1).astype(dtype=float)
 
                 dt_pointers[cat_idx][area_idx] = {
                     "dt_ids": dt_ids,


### PR DESCRIPTION
Addresses #37, and has been fixed in PR #39, but #39 was merged to `lvis_challenge_2021` branch. This branch is not compatible with the LVIS evaluator in D2 (due to argument changes in `LVISResults`), so I am requesting to merge this change to the main branch as well.
